### PR TITLE
Use release drafter 7.1.1

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,7 +10,8 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@6db134d15f3909ccc9eefd369f02bd1e9cffdf97 # v6
+      - name: Release Drafter
+        uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         env:
           # This token is generated automatically by default in GitHub Actions: no need to create it manually
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,6 +2,8 @@ name: Release Drafter
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
   release:
     types: [released]
 # Only allow 1 release-drafter build at a time to avoid creating multiple "next" releases
@@ -12,6 +14,6 @@ jobs:
     steps:
       - name: Release Drafter
         uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
-        env:
+        with:
           # This token is generated automatically by default in GitHub Actions: no need to create it manually
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Use release drafter 7.1.1

- **Use release drafter 7.1.1**
- **Release drafter 7.0.0 uses `with: token` instead of `env: GITHUB_TOKEN`**
