### PR TITLE
chore(Dockerfile): replace npm install with npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:24.13.0 as builder
 WORKDIR /app
 COPY ["package.json", "package-lock.json*", "./"]
-RUN npm install
+RUN npm ci
 COPY . .
 RUN npm run build
 # hadolint ignore=DL3059
@@ -18,10 +18,9 @@ ARG GIT_COMMIT_REV
 ENV GIT_COMMIT_REV=$GIT_COMMIT_REV
 ENV NODE_ENV=production
 COPY --chown=node:node ["package.json", "package-lock.json*", "./"]
-RUN npm install --production
+RUN npm ci --production
 
 COPY --chown=node:node . .
 COPY --chown=node:node --from=builder /app/dist ./dist
 
 CMD [ "node", "./dist/bin/www" ]
-


### PR DESCRIPTION
Ref:

- https://github.com/jenkins-infra/helpdesk/issues/5119

enforcing npm ci over npm install across CI/CD pipelines for reproducible builds.

- `Dockerfile`: `npm install` → `npm ci` in builder stage
- `Dockerfile`: `npm install --production` → `npm ci --production` in production stage
